### PR TITLE
Added base64 encoded integration of images into HTML log (#71)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ ScreenCapLibrary has the following extra features:
     - Video capture in WebM format, embeddable in log files
     - Adjusting the compression/quality of the screenshots
     - Support for GIFs
+    - optional base64 encoded embedding of images into log files 
     - Taking multiple screenshots in a given amount of time
     - Support for partial screen captures
     - Configurable monitor screen grabbing for screenshots and recording

--- a/src/ScreenCapLibrary/gifclient.py
+++ b/src/ScreenCapLibrary/gifclient.py
@@ -25,10 +25,11 @@ class GifClient(Client):
         self.optimize = None
 
     def start_gif_recording(self, name, size_percentage,
-                            embed, embed_width, monitor, optimize):
+                            embed, embed_width, embed64, monitor, optimize):
         self.name = name
         self.embed = embed
         self.embed_width = embed_width
+        self.embed64 = embed64
         self.optimize = optimize
         self.path = self._save_screenshot_path(basename=self.name, format='gif')
         self.futures = self.grab_frames(size_percentage, self._stop_condition, int(monitor))
@@ -36,14 +37,16 @@ class GifClient(Client):
 
     def stop_gif_recording(self):
         self._stop_thread()
-        if is_truthy(self.embed):
-            self._embed_screenshot(self.path, self.embed_width)
         if is_truthy(self.optimize):
             frames = []
             for frame in ImageSequence.Iterator(Image.open(self.path)):
                 frame = frame.copy()
                 frames.append(frame)
             frames[0].save(self.path, save_all=True, append_images=frames[1:], optimize=True)
+        if is_truthy(self.embed64):
+            self._embed_base64_screenshot(self.path, self.embed_width, 'gif')
+        elif is_truthy(self.embed):
+            self._embed_screenshot(self.path, self.embed_width)
         return self.path
 
     @run_in_background

--- a/src/ScreenCapLibrary/library.py
+++ b/src/ScreenCapLibrary/library.py
@@ -57,6 +57,12 @@ class ScreenCapLibrary:
     `Set Screenshot Directory` keyword during execution. It is also possible
     to save screenshots using an absolute path.
 
+    Screenshots and GIF recordings can also be integrated into the log file. 
+    The `embed` parameter links the image into the HTML log. 
+    The `embed64` parameter integrates the images base64 encoded into the
+    HTML log. This makes RF logs processable by 3rd party tools without caring 
+    for external linked image files. (File size must be kept in view, though...)
+
     = Time format =
 
     All delays and time intervals can be given as numbers considered seconds
@@ -150,7 +156,7 @@ class ScreenCapLibrary:
         """
         return self.client.set_screenshot_directory(path)
 
-    def take_screenshot(self, name='screenshot', format=None, quality=None, width='800px', delay=0, monitor=1):
+    def take_screenshot(self, name='screenshot', format=None, quality=None, width='800px', delay=0, monitor=1, embed64=False):
         """Takes a screenshot in the specified format at library import and
         embeds it into the log file (PNG by default).
 
@@ -172,12 +178,16 @@ class ScreenCapLibrary:
         ``quality`` can take values in range [0, 100]. In case of JPEG format
         it can drastically reduce the file size of the image.
 
-        ``width`` specifies the size of the screenshot in the log file.
+        ``width`` specifies the size of the screenshot in the log file (default: 800px)
+        To have inscaled screenshots in the HTML log, set `width=None`.
 
         ``delay`` specifies the waiting time before taking a screenshot. See
         `Time format` section for more information. By default the delay is 0.
 
         ``monitor`` selects which monitor you want to capture. Use value 0 to capture all.
+
+        ``embed64`` integrates the screenshot as base64 encoded image into the 
+        HTML log file instead of linking it.
 
         Examples: (LOGDIR is determined automatically by the library)
         | `Take Screenshot` |                  |            | # LOGDIR/screenshot_1.png (index automatically incremented) |
@@ -187,13 +197,14 @@ class ScreenCapLibrary:
         | `Take Screenshot` | images/login.jpg | 300px      | # Specify both name and width. |
         | `Take Screenshot` | width=550px      |            | # Specify only width. |
         | `Take Screenshot` | format=jpg       | quality=15 | # Specify both image format and quality |
+        | `Take Screenshot` | embed64=true     |            | # Embed as base64 image |
 
         The path where the screenshot is saved is returned.
         """
-        return self.client.take_screenshot(name, format, quality, width, delay, monitor)
+        return self.client.take_screenshot(name, format, quality, width, delay, monitor, embed64)
 
     def start_gif_recording(self, name="screenshot", size_percentage=0.5,
-                            embed=True, embed_width='800px', monitor=1, optimize=True):
+                            embed=True, embed_width='800px', embed64=False, monitor=1, optimize=True):
         """
         Starts the recording of a GIF in the background with the specified ``name``.
         The recording can be stopped by calling the `Stop Gif Recording` keyword.
@@ -208,12 +219,16 @@ class ScreenCapLibrary:
         ``embed`` specifies if the screenshot should be embedded in the log file
         or not. See `Boolean arguments` section for more details.
 
-        ``embed_width`` specifies the size of the screenshot that is
-        embedded in the log file.
+        ``embed_width`` specifies the size of the screenshot that is embedded in the 
+        log file (default: 800px). 
+        To have unscaled screenshots in the HTML log, set `embed_width=None`.
 
         ``monitor`` selects which monitor you want to capture. Use value 0 to capture all.
 
         ``optimize`` drastically reduces the size (and quality) of the gif file.
+
+        ``embed64`` integrates the GIF recording as base64 encoded image into the 
+        HTML log file instead of linking it.
 
         Examples:
         | `Start Gif Recording` |            |  # Starts the GIF recording in background |
@@ -225,7 +240,7 @@ class ScreenCapLibrary:
             raise Exception('A gif recording is already in progress!')
         gif_client = GifClient(self.client.screenshot_module, self.client.screenshot_dir)
         self.started_gifs.append(gif_client)
-        gif_client.start_gif_recording(name, size_percentage, embed, embed_width, monitor, optimize)
+        gif_client.start_gif_recording(name, size_percentage, embed, embed_width, embed64, monitor, optimize)
 
     def stop_gif_recording(self):
         """
@@ -241,7 +256,7 @@ class ScreenCapLibrary:
             raise error
 
     def take_partial_screenshot(self, name='screenshot', format=None, quality=None,
-                                left=0, top=0, width=700, height=300, embed=True, embed_width='800px', monitor=1):
+                                left=0, top=0, width=700, height=300, embed=True, embed_width='800px', monitor=1, embed64=False):
         """
         Takes a partial screenshot in the specified format and dimensions at
         library import and embeds it into the log file (PNG by default).
@@ -259,12 +274,18 @@ class ScreenCapLibrary:
         ``embed`` specifies if the screenshot should be embedded in the log file or not. See
         `Boolean arguments` section for more details.
 
-        ``embed_width`` specifies the size of the screenshot that is embedded in the log file.
+        ``embed_width`` specifies the size of the screenshot that is embedded in the HTML 
+        log file (default: 800px).
+        To have inscaled screenshots in the HTML log, set `width=None`.
 
         ``monitor`` selects which monitor you want to capture. Use value 0 to capture all.
+
+        ``embed64`` integrates the screenshot as base64 encoded image into the 
+        HTML log file instead of linking it.
+        
         """
         return self.client.take_partial_screenshot(name, format, quality,
-                                                   left, top, width, height, embed, embed_width, monitor)
+                                                   left, top, width, height, embed, embed_width, monitor, embed64)
 
     def take_screenshot_without_embedding(self, name="screenshot", format=None, quality=None, delay=0, monitor=1):
         """Takes a screenshot and links it from the log file.


### PR DESCRIPTION
Hello @mihaiparvu,

this pull request extends the ScreenCapLibrary by the base64 encoded integration of images into the RF HTML log file (as known from SeleniumLibrary of Browser and requested in #71 )

To be more concrete, it adds the argument `embed64` to the following keywords: 

- `Take Screeenshot`
- `Take Partial Screeenshot`
- `Start GIF Recording`

Honestly, the already used term "embed" here suggests that the images are _embedded_ indeed _into the HTML_ log, but what this currently does is only _to link them_. 

For [Robotmk](https://www.robotmk.org), I needed HTML logs without any external linked files to transport them over to [Checkmk](https://www.checkmk.com). 
For this, I created the argument `embed64` to communicate that in this case a _base64 encoded image will be the in the HTML log_. This keeps compatibility with existing code. 
When `embed64` is used, after the image got embedded into the HTML log, the original image file on the file system gets deleted to leave everything clean behind. 

In e2e monitoring it is crucial (especially for customers...) to see the cause of failed tests. 
By default the width in ScreenCapLibrary is always set to 800px which leads to blurry images (and makes it hard to guess the right width). To have images always in their original size, the library now checks the `width` parameter for a `None` value. In that case, no width is used at all and the images appear in their original size. 

Thanks for the efforts you put so far into this versatile library. 
Can't wait to hear your thoughts! ;-) 

Kind regards,
Simon

```
*** Test Cases ***
Test default
    Take Screenshot  embed64=True  width=None
Test Partial
    Take Partial Screenshot  embed64=True  top=0  left=0  width=250  height=250  embed_width=None
Test Gif Recording
    Start Gif Recording  embed64=True  optimize=False  embed_width=None  size_percentage=1.0
    Sleep  3
    Stop Gif Recording
```
![2021-11-26 22 53 13](https://user-images.githubusercontent.com/1897410/143657779-03407bbd-c164-4959-ad12-6b1d5d339812.gif)


